### PR TITLE
upgrade version for jackson-databind

### DIFF
--- a/drivers/Connector-J/pom.xml
+++ b/drivers/Connector-J/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.3</version>
+            <version>2.8.11</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
upgrade version for jackson-databind to 2.8.11
