### PR TITLE
fix autotest-dble-2.20.04 fail at 29

### DIFF
--- a/behave_dble/features/func_test/managercmd/disable_enable_ha.feature
+++ b/behave_dble/features/func_test/managercmd/disable_enable_ha.feature
@@ -73,9 +73,9 @@ Feature: test high-availability related commands
       | sql               |
       | show @@datasource |
     Then check resultset "show_ds_rs" has lines with following column values
-    | DATAHOST-0 | NAME-1   | HOST-2        | PORT-3 | W/R-4  | ACTIVE-5 | DISABLED-11 |
-    | ha_group2  | hostM2   | 172.100.9.6   | 3306   | R      |      1   | false       |
-    | ha_group2  | slave1   | 172.100.9.2   | 3306   | W      |      1   | false       |
+    | DATAHOST-0 | NAME-1   | HOST-2        | PORT-3 | W/R-4  | ACTIVE-5   | DISABLED-11 |
+    | ha_group2  | hostM2   | 172.100.9.6   | 3306   | R      |      1+1   | false       |
+    | ha_group2  | slave1   | 172.100.9.2   | 3306   | W      |      1+1   | false       |
     Then check exist xml node "{'tag':'dataHost/writeHost/readHost','kv_map':{'host':'hostM2','disabled':'false'}}" in "/opt/dble/conf/schema.xml" in host "dble-1"
     Then check exist xml node "{'tag':'dataHost/writeHost','kv_map':{'host':'slave1','disabled':'false'}}" in "/opt/dble/conf/schema.xml" in host "dble-1"
 #    dble-2 is slave1's server

--- a/behave_dble/features/steps/resultset_compare.py
+++ b/behave_dble/features/steps/resultset_compare.py
@@ -111,7 +111,7 @@ def step_impl(context, rs_name):
                     expect_max = int(expect[-1])+expect_min
                     real_col = int(real_col)
                     isFound = (real_col >= expect_min) and (real_col <= expect_max)
-                    context.logger.de("col index:{0}, expect col_min:{1}<= real_col:{2}<=col_max:{3}".format(i, expect_min, real_col, expect_max))
+                    context.logger.debug("col index:{0}, expect col_min:{1}<= real_col:{2}<=col_max:{3}".format(i, expect_min, real_col, expect_max))
                 else:
                     expect_col = expect_row[i]
                     if (expect_row[i].rfind('[0-9].[0-9]') != -1):


### PR DESCRIPTION
Reason:  
  fix ci 29 fail for not stable active connection number
Type:  
  BUG/Improve  
Influences：  
   fix xx
