### PR TITLE
keep_DBLE0REQ-486 add docker images of mysql 8.0

### DIFF
--- a/behave_dble/compose/docker-build-mysql8/Dockerfile
+++ b/behave_dble/compose/docker-build-mysql8/Dockerfile
@@ -1,0 +1,52 @@
+From centos:centos7
+
+#libaio numaactl.x86_64 needed by mysql
+RUN yum install -y wget net-tools libaio numactl.x86_64 openssh-clients openssh-server libmysqlclient gcc python3-devel.x86_64 vim less iproute && \
+    yum clean all && \
+    yum install -y openssl > /tmp/install_openssl.log && \
+    echo 'root:sshpass' | chpasswd && \
+    sed -i 's/session\s*required\s*pam_loginuid.so/session optional pam_loginuid.so/g' /etc/pam.d/sshd && \
+    sed -i 's/GSSAPIAuthentication.*/GSSAPIAuthentication no/g' /etc/ssh/sshd_config && \
+    sed -i "s/#UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && \
+    sed -i 's/#UseDNS.*/UseDNS no/g' /etc/ssh/sshd_config && \
+    sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config && \
+    ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    localedef -i zh_CN -f UTF-8 zh_CN.UTF-8 && \
+    localedef -i en_US -f UTF-8 en_US.UTF-8
+ENV LC_ALL=zh_CN.UTF-8
+
+COPY my.cnf /etc/my.cnf
+COPY mysql_init.sh /usr/local/bin/mysql_init.sh
+RUN chmod +x /usr/local/bin/mysql_init.sh
+
+#install mysql
+COPY mysql-8.0.21-linux-glibc2.12-x86_64.tar.xz /tmp/mysql-8.0.21-linux-glibc2.12-x86_64.tar.xz
+RUN mkdir /usr/local/mysql && \
+    echo "$(pwd)"  && \
+    echo "ls -l" && \
+    tar xvf /tmp/mysql-8.0.21-linux-glibc2.12-x86_64.tar.xz -C /usr/local/mysql --strip-components=1 && \
+    groupadd mysql && \
+    useradd -r -g mysql -s /bin/false mysql && \
+    cd /usr/local/mysql && mkdir data && chown -R mysql:mysql . && \
+    echo "ALTER USER 'root'@'localhost' IDENTIFIED BY '111111';" > /usr/local/mysql/mysql-init && \
+    echo "export PATH=/usr/local/mysql/bin:$PATH">>/etc/bashrc && \
+    rm -f /tmp/mysql-8.0.21-linux-glibc2.12-x86_64.tar.xz
+
+RUN ssh-keygen -A && \
+    mkdir ~/.ssh && \
+    echo 'sshpass'| passwd --stdin root
+
+#sshd service
+RUN rm -rf /etc/ssh/ssh_host_* && \
+    ssh-keygen -q -t rsa -b 2048 -f /etc/ssh/ssh_host_rsa_key -N '' && \
+    ssh-keygen -q -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N '' && \
+    ssh-keygen -t dsa -f /etc/ssh/ssh_host_ed25519_key -N '' && \
+    ssh-keygen -t rsa -N ""  -f "/root/.ssh/id_rsa"
+
+COPY * /docker-build/
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
+    ln -s /usr/local/bin/docker-entrypoint.sh /
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/behave_dble/compose/docker-build-mysql8/docker-entrypoint.sh
+++ b/behave_dble/compose/docker-build-mysql8/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo $1 >/tmp/zhjtest.log
+if [ "$1" = "dble" ]; then
+    echo "$2"> /opt/zookeeper/data/myid
+fi
+
+if [ "$1" = "mysql" -o "$1" = "dble" ]; then
+    sed -i "/server-id=/c server-id=$2" /etc/my.cnf
+fi
+
+exec /usr/sbin/sshd -D

--- a/behave_dble/compose/docker-build-mysql8/my.cnf
+++ b/behave_dble/compose/docker-build-mysql8/my.cnf
@@ -1,0 +1,20 @@
+[client]
+user=test
+password=111111
+host=127.0.0.1
+[mysqld]
+basedir=/usr/local/mysql
+init-file=/usr/local/mysql/mysql-init
+default_authentication_plugin=mysql_native_password
+server-id=10
+session_track_schema=1
+session_track_state_change=1
+session_track_system_variables="*"
+gtid-mode=on
+enforce_gtid_consistency=on
+secure_file_priv=
+sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
+
+# PLUGINS
+plugin_load = "rpl_semi_sync_master=semisync_master.so;rpl_semi_sync_slave=semisync_slave.so;group_replication=group_replication.so;clone=mysql_clone.so"
+

--- a/behave_dble/compose/docker-build-mysql8/mysql_init.sh
+++ b/behave_dble/compose/docker-build-mysql8/mysql_init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+/usr/local/mysql/bin/mysqld --initialize-insecure --basedir=/usr/local/mysql --datadir=/usr/local/mysql/data  --user=mysql >/dev/null 2>&1
+mkdir -p /var/lib/mysql && touch /var/lib/mysql/auto.cnf && echo "server-uuid=$(uuidgen)" > /var/lib/mysql/auto.cnf
+/usr/local/mysql/bin/mysqld_safe --defaults-file=/etc/my.cnf --user=mysql >/dev/null 2>&1 &
+sleep 30s && /usr/local/mysql/bin/mysql -uroot -p111111 -e "flush privileges;alter user root@'localhost' identified by '111111'"
+echo -e "alias mysql='mysql -uroot -p111111'" >> /root/.bashrc
+. ~/.bashrc


### PR DESCRIPTION
Reason:  
  keep_DBLE0REQ-486 add docker images of mysql 8.0
Type:  
  Improve  
Influences：  
   http://10.186.18.11/jira/browse/DBLE0REQ-486
